### PR TITLE
Allow unneccessary fat arrows to not trigger errors

### DIFF
--- a/lib/linter-coffee-variables.coffee
+++ b/lib/linter-coffee-variables.coffee
@@ -118,6 +118,8 @@ lint = (TextEditor) ->
     cache = js: js, errors: errors
     debug.timeEnd 'Running ESLint'
     return errors
+      # Allow fat arrows to not trigger "this is not defined"
+      .filter (error) -> error.text.indexOf('"_this"') == -1
 
   else
     return []

--- a/spec/fixture.coffee
+++ b/spec/fixture.coffee
@@ -19,7 +19,7 @@ f2 = (f2a1, f2a2) -> # ok
   f2a3 # arg3 undefined
   f2a4 # arg4 undefined
 
-f3 = (f4a1) -> # ok
+f3 = (f4a1) => # ok with fat arrow
   f4a1.foo # ok
 
 f3 = (f4a1) -> # f4a1 unused


### PR DESCRIPTION
The code I use has fat arrows where unnecessary. With ES2015 it is only natural to use them everywhere. Besides, the name of the plugin seems to be about unused variables and not the unnecessary usage of fat arrows. Besides, the error is very confusing anyway, as there is no "_this" in our code nowhere.
